### PR TITLE
add default key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ WORKDIR /home/ubuntu
 RUN mkdir -p /home/nf2/.ssh/ && \
     chmod 0700 /home/nf2/.ssh  && \
     touch /home/nf2/.ssh/authorized_keys && \
-    chmod 600 /home/nf2/.ssh/authorized_keys
+    chmod 600 /home/nf2/.ssh/authorized_keys && \
+    touch /home/nf2/.ssh/config && \
+    chmod 600 /home/nf2/.ssh/config
 
 COPY ssh-keys/ /keys/
 RUN cat /keys/ssh_test.pub >> /home/nf2/.ssh/authorized_keys
+RUN cat /keys/config >> /home/nf2/.ssh/config
 
 USER root
 ENTRYPOINT service ssh start && bash

--- a/ssh-keys/config
+++ b/ssh-keys/config
@@ -1,0 +1,3 @@
+Host *
+    StrictHostKeyChecking no
+    IdentityFile /keys/id_rsa


### PR DESCRIPTION
At first I've tried to change my entry-point to a file that contains the following :

```sh
#!/bin/bash
set -e

service ssh start

su nf2 -c 'eval $(ssh-agent) && ssh-add /keys/id_rsa'

#keep docker running
while true; do
  echo "Press [CTRL+C] to stop.."
  sleep 10
done
```

The drawback is while loop to keep the docker container up and ssh-add is not permanent. I choose to add a config file it's more convenient I think (I'm not a ssh or system expert)
